### PR TITLE
Remove failsafe from coverage command

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"build:css": "postcss src/styles/tailwind.css -o src/styles/main.css",
 		"test": "react-scripts test",
 		"eject": "react-scripts eject",
-		"coverage": "CI=true react-scripts test --coverage --watchAll=false || true"
+		"coverage": "CI=true react-scripts test --coverage --watchAll=false"
 	},
 	"eslintConfig": {
 		"extends": "react-app"


### PR DESCRIPTION
# Description

Fixes failing tests from being mergeable due to ignoring failing statuses with the `|| true` statement

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [ ] Complete, tested, ready to review and merge
- [x] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Untested here, but the same change was tested and committed to the backend repo.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
